### PR TITLE
RF-393 fix metais parser unable to save models

### DIFF
--- a/app/jobs/metais/sync_document_job.rb
+++ b/app/jobs/metais/sync_document_job.rb
@@ -22,9 +22,9 @@ class Metais::SyncDocumentJob < ApplicationJob
              meta['type'] == JSON.parse(document.latest_version.raw_meta)['type'])
         )
 
+      document.save!
       version = document.versions.build(raw_data: json.to_json, raw_meta: meta.to_json)
       parse_document(version, json, meta)
-      document.save!
       version.save!
       document.latest_version = version
       document.save!

--- a/app/jobs/metais/sync_isvs_job.rb
+++ b/app/jobs/metais/sync_isvs_job.rb
@@ -16,9 +16,9 @@ class Metais::SyncIsvsJob < ApplicationJob
     ActiveRecord::Base.transaction do
       return unless isvs.latest_version.nil? || isvs.latest_version.raw_data != json.to_json
       
+      isvs.save!
       version = isvs.versions.build(raw_data: json.to_json)
       parse_isvs(version, json)
-      isvs.save!
       version.save!
       isvs.latest_version = version
       isvs.save!

--- a/app/jobs/metais/sync_project_job.rb
+++ b/app/jobs/metais/sync_project_job.rb
@@ -18,9 +18,9 @@ class Metais::SyncProjectJob < ApplicationJob
     ActiveRecord::Base.transaction do
       return unless project.latest_version.nil? || project.latest_version.raw_data != json.to_json
 
+      project.save!
       version = project.versions.build(raw_data: json.to_json)
       parse_project(version, json)
-      project.save!
       version.save!
       project.latest_version = version
       project.save!


### PR DESCRIPTION
Takáto zmena, že parent model uložíme na začiatku, vyriešila problém s tým, že sa to nechcelo ukladať.