### PR TITLE
RF-393 Fix metais codelists language headers and add uuid to program

### DIFF
--- a/app/jobs/metais/sync_codelist_investment_type_job.rb
+++ b/app/jobs/metais/sync_codelist_investment_type_job.rb
@@ -7,7 +7,7 @@ class Metais::SyncCodelistInvestmentTypeJob < ApplicationJob
 
   def perform
     conn = Faraday.new(url: API_ENDPOINT)
-    response = conn.get('', 'Content-Type' => 'application/json')
+    response = conn.get('', nil, {'Content-Type' => 'application/json', 'Accept-Language' => 'sk-SK,sk;q=0.8'})
     parsed_json = JSON.parse(response.body)
 
     ActiveRecord::Base.transaction do

--- a/app/jobs/metais/sync_codelist_program_job.rb
+++ b/app/jobs/metais/sync_codelist_program_job.rb
@@ -15,6 +15,7 @@ class Metais::SyncCodelistProgramJob < ApplicationJob
       ActiveRecord::Base.transaction do
         parsed_json['configurationItemSet'].each do |i|
           program = Metais::CodelistProgram.find_or_initialize_by(kod_metais: get_attribute(i, 'Gen_Profil_kod_metais'))
+          program.uuid = i&.dig('uuid')
           program.nazov = get_attribute(i, 'Gen_Profil_nazov')
           program.nazov_en = get_attribute(i, 'Gen_Profil_anglicky_nazov')
           program.ref_id = get_attribute(i, 'Gen_Profil_ref_id')

--- a/app/jobs/metais/sync_codelist_project_phase_job.rb
+++ b/app/jobs/metais/sync_codelist_project_phase_job.rb
@@ -7,7 +7,7 @@ class Metais::SyncCodelistProjectPhaseJob < ApplicationJob
 
   def perform
     conn = Faraday.new(url: API_ENDPOINT)
-    response = conn.get('', 'Content-Type' => 'application/json')
+    response = conn.get('', nil, {'Content-Type' => 'application/json', 'Accept-Language' => 'sk-SK,sk;q=0.8'})
     parsed_json = JSON.parse(response.body)
 
     ActiveRecord::Base.transaction do

--- a/app/jobs/metais/sync_codelist_project_state_job.rb
+++ b/app/jobs/metais/sync_codelist_project_state_job.rb
@@ -7,7 +7,7 @@ class Metais::SyncCodelistProjectStateJob < ApplicationJob
   
   def perform
     conn = Faraday.new(url: API_ENDPOINT)
-    response = conn.get('', 'Content-Type' => 'application/json')
+    response = conn.get('', nil, {'Content-Type' => 'application/json', 'Accept-Language' => 'sk-SK,sk;q=0.8'})
     parsed_json = JSON.parse(response.body)
   
     ActiveRecord::Base.transaction do

--- a/app/jobs/metais/sync_codelist_source_job.rb
+++ b/app/jobs/metais/sync_codelist_source_job.rb
@@ -7,7 +7,7 @@ class Metais::SyncCodelistSourceJob < ApplicationJob
   
   def perform
     conn = Faraday.new(url: API_ENDPOINT)
-    response = conn.get('', 'Content-Type' => 'application/json')
+    response = conn.get('', nil, {'Content-Type' => 'application/json', 'Accept-Language' => 'sk-SK,sk;q=0.8'})
     parsed_json = JSON.parse(response.body)
   
     ActiveRecord::Base.transaction do

--- a/app/jobs/metais/sync_projects_isvs_job.rb
+++ b/app/jobs/metais/sync_projects_isvs_job.rb
@@ -11,7 +11,7 @@ class Metais::SyncProjectsIsvsJob < ApplicationJob
     page_number = 1
 
     begin
-      response = conn.get(RELATED_ISVS_REQUEST_TEMPLATE % {uuid: project.uuid}, 'Content-Type' => 'application/json')
+      response = conn.get(RELATED_ISVS_REQUEST_TEMPLATE % {uuid: project.uuid}, nil, 'Content-Type' => 'application/json')
       parsed_json = JSON.parse(response.body)
       isvs = parsed_json&.dig('ciWithRels')
       return unless isvs

--- a/db/migrate/20220902164827_add_uuid_to_metais_codelist_program.rb
+++ b/db/migrate/20220902164827_add_uuid_to_metais_codelist_program.rb
@@ -1,0 +1,5 @@
+class AddUuidToMetaisCodelistProgram < ActiveRecord::Migration[6.0]
+  def change
+    add_column 'metais.codelist_program', :uuid, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4052,7 +4052,8 @@ CREATE TABLE metais.codelist_program (
     zdroj character varying,
     raw_data text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    uuid character varying
 );
 
 
@@ -10839,6 +10840,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220810120123'),
 ('20220810120320'),
 ('20220810120510'),
-('20220811192959');
+('20220811192959'),
+('20220902164827');
 
 


### PR DESCRIPTION
Číselníky to pôvodne poťahalo po anglicky, aj keď tam bol get parameter `lang=sk`. Chcelo to v hlavičke `Accept-Language`. Tak som to zmenil, plus som zistil, že som pri get requestoch posielal parametre a nie hlavičky.

Druhá zmena je pridanie `uuid` do čísleníka programov, lebo cez to sú referencované v projektoch.