### PR TITLE
ECO-277/find-upvs-urls-with-sparql

### DIFF
--- a/app/jobs/upvs/fetch_public_authority_active_edesks_list_job.rb
+++ b/app/jobs/upvs/fetch_public_authority_active_edesks_list_job.rb
@@ -1,10 +1,8 @@
 class Upvs::FetchPublicAuthorityActiveEdesksListJob < ApplicationJob
   queue_as :upvs
 
-  DATASET_URL = 'https://data.slovensko.sk/download?id=794af827-132b-46d1-98e7-ccd73eda26e0'
-
-  def perform(downloader: HarvesterUtils::Downloader)
-    csv_file = downloader.download_file(DATASET_URL)
+  def perform(dataset_url, downloader: HarvesterUtils::Downloader)
+    csv_file = downloader.download_file(dataset_url)
     csv_options = { col_sep: File.open(csv_file) { |f| f.readline }.include?(';') ? ';' : ',', headers: true }
 
     TemporaryPublicAuthorityActiveEdesk.transaction do

--- a/app/jobs/upvs/fetch_public_authority_edesks_list_job.rb
+++ b/app/jobs/upvs/fetch_public_authority_edesks_list_job.rb
@@ -1,10 +1,8 @@
 class Upvs::FetchPublicAuthorityEdesksListJob < ApplicationJob
   queue_as :upvs
 
-  DATASET_URL = 'https://data.slovensko.sk/download?id=7c70f6c9-1777-4d8a-8711-f1dfd2359620'
-
-  def perform(downloader: HarvesterUtils::Downloader)
-    csv_file = downloader.download_file(DATASET_URL)
+  def perform(dataset_url, downloader: HarvesterUtils::Downloader)
+    csv_file = downloader.download_file(dataset_url)
     csv_options = { col_sep: File.open(csv_file) { |f| f.readline }.include?(';') ? ';' : ',', headers: true }
 
     TemporaryPublicAuthorityEdesk.transaction do

--- a/app/jobs/upvs/fetch_services_with_forms_list_job.rb
+++ b/app/jobs/upvs/fetch_services_with_forms_list_job.rb
@@ -1,10 +1,8 @@
 class Upvs::FetchServicesWithFormsListJob < ApplicationJob
   queue_as :upvs
 
-  DATASET_URL = 'https://data.slovensko.sk/download?id=c78de203-caa5-4d1d-9496-975f0e2567d1'
-
-  def perform(downloader: HarvesterUtils::Downloader)
-    zip_file = downloader.download_file(DATASET_URL)
+  def perform(dataset_url, downloader: HarvesterUtils::Downloader)
+    zip_file = downloader.download_file(dataset_url)
     csv_file = downloader.extract_csv(zip_file)
 
     csv_options = {

--- a/app/jobs/upvs/find_public_authority_active_edesks_list_job.rb
+++ b/app/jobs/upvs/find_public_authority_active_edesks_list_job.rb
@@ -1,0 +1,37 @@
+require 'faraday'
+
+class Upvs::FindPublicAuthorityActiveEdesksListJob < ApplicationJob
+  queue_as :upvs
+
+  SET_URL = 'https://data.gov.sk/set/28c2c7ee-6a43-4746-9e3f-35e977f6f03d'
+  BASE_URL = 'https://data.slovensko.sk/api/sparql'
+
+  def perform
+    query = "
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX dcat: <http://www.w3.org/ns/dcat#>
+      SELECT ?downloadURL
+      WHERE {
+        <#{SET_URL}> dct:hasPart ?dataset .
+        ?dataset dcat:distribution ?distribution .
+        ?dataset dct:issued ?issued .
+        ?dataset dct:modified ?modified .
+        ?dataset dcat:distribution ?distribution .
+        ?distribution dcat:downloadURL ?downloadURL .
+      }
+      ORDER BY DESC(?modified)
+      LIMIT 2
+    "
+
+    response = Faraday.get(BASE_URL, {query: query})
+
+    if response.success?
+      csv_dataset_url = response.body.split("\n")[1..].map(&:strip)
+                          .find { |url| Faraday.get(url).headers['Content-Disposition']&.include?('.csv') }
+
+      Upvs::FetchPublicAuthorityActiveEdesksListJob.perform_now(csv_dataset_url) if csv_dataset_url
+    else
+      raise "Request to find latest dataset URL for set: #{SET_URL} failed with status code #{response.status}"
+    end
+  end
+end

--- a/app/jobs/upvs/find_public_authority_active_edesks_list_job.rb
+++ b/app/jobs/upvs/find_public_authority_active_edesks_list_job.rb
@@ -27,10 +27,12 @@ class Upvs::FindPublicAuthorityActiveEdesksListJob < ApplicationJob
     response = Faraday.get(BASE_URL, {query: query})
 
     if response.success?
-      csv_dataset_url = response.body.split("\n")[1..].map(&:strip)
+      dataset_url = response.body.split("\n")[1..].map(&:strip)
                                                       .find { |url| Faraday.get(url).headers['Content-Disposition']&.include?('.csv') }
 
-      Upvs::FetchPublicAuthorityActiveEdesksListJob.perform_now(csv_dataset_url) if csv_dataset_url
+      raise "Dataset URL not found in response. Job: Upvs::FindPublicAuthorityActiveEdesksListJob" if dataset_url.nil?
+
+      Upvs::FetchPublicAuthorityActiveEdesksListJob.perform_now(dataset_url)
     else
       raise "Request to find latest dataset URL for set: #{SET_URL} failed with status code #{response.status}"
     end

--- a/app/jobs/upvs/find_public_authority_edesks_list_job.rb
+++ b/app/jobs/upvs/find_public_authority_edesks_list_job.rb
@@ -30,7 +30,9 @@ class Upvs::FindPublicAuthorityEdesksListJob < ApplicationJob
       dataset_url = response.body.split("\n")[1..].map(&:strip)
                                                   .find { |url| Faraday.get(url).headers['Content-Disposition']&.include?('.csv') }
 
-      Upvs::FetchPublicAuthorityEdesksListJob.perform_now(dataset_url) if dataset_url
+      raise "Dataset URL not found in response. Job: Upvs::FindPublicAuthorityEdesksListJob" if dataset_url.nil?
+
+      Upvs::FetchPublicAuthorityEdesksListJob.perform_now(dataset_url)
     else
       raise "Request to find latest dataset URL for set: #{SET_URL} failed with status code #{response.status}"
     end

--- a/app/jobs/upvs/find_public_authority_edesks_list_job.rb
+++ b/app/jobs/upvs/find_public_authority_edesks_list_job.rb
@@ -1,0 +1,35 @@
+require 'faraday'
+
+class Upvs::FindPublicAuthorityEdesksListJob < ApplicationJob
+  queue_as :upvs
+
+  SET_URL = 'https://data.gov.sk/set/8572f288-0186-4bc2-8d12-9eb324ff47bd'
+  BASE_URL = 'https://data.slovensko.sk/api/sparql'
+
+  def perform
+    query = "
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX dcat: <http://www.w3.org/ns/dcat#>
+      SELECT ?downloadURL
+      WHERE {
+        <#{SET_URL}> dct:hasPart ?dataset .
+        ?dataset dcat:distribution ?distribution .
+        ?dataset dct:issued ?issued .
+        ?dataset dct:modified ?modified .
+        ?dataset dcat:distribution ?distribution .
+        ?distribution dcat:downloadURL ?downloadURL .
+      }
+      ORDER BY DESC(?modified)
+      LIMIT 1
+    "
+
+    response = Faraday.get(BASE_URL, {query: query})
+
+    if response.success?
+      dataset_url = response.body.split("\n")[1].strip
+      Upvs::FetchPublicAuthorityEdesksListJob.perform_now(dataset_url)
+    else
+      raise "Request to find latest dataset URL for set: #{SET_URL} failed with status code #{response.status}"
+    end
+  end
+end

--- a/app/jobs/upvs/find_services_with_forms_list_job.rb
+++ b/app/jobs/upvs/find_services_with_forms_list_job.rb
@@ -30,7 +30,9 @@ class Upvs::FindServicesWithFormsListJob < ApplicationJob
       dataset_url = response.body.split("\n")[1..].map(&:strip)
                                                   .find { |url| Faraday.get(url).headers['Content-Disposition']&.include?('.zip') }
 
-      Upvs::FetchServicesWithFormsListJob.perform_now(dataset_url) if dataset_url
+      raise "Dataset URL not found in response. Job: Upvs::FindServicesWithFormsListJob" if dataset_url.nil?
+
+      Upvs::FetchServicesWithFormsListJob.perform_now(dataset_url)
     else
       raise "Request to find latest dataset URL for set: #{SET_URL} failed with status code #{response.status}"
     end

--- a/app/jobs/upvs/find_services_with_forms_list_job.rb
+++ b/app/jobs/upvs/find_services_with_forms_list_job.rb
@@ -1,0 +1,35 @@
+require 'faraday'
+
+class Upvs::FindServicesWithFormsListJob < ApplicationJob
+  queue_as :upvs
+
+  SET_URL = 'https://data.gov.sk/set/9eeac271-ae1c-40f8-bb90-7089a9fcb659'
+  BASE_URL = 'https://data.slovensko.sk/api/sparql'
+
+  def perform
+    query = "
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX dcat: <http://www.w3.org/ns/dcat#>
+      SELECT ?downloadURL
+      WHERE {
+        <#{SET_URL}> dct:hasPart ?dataset .
+        ?dataset dcat:distribution ?distribution .
+        ?dataset dct:issued ?issued .
+        ?dataset dct:modified ?modified .
+        ?dataset dcat:distribution ?distribution .
+        ?distribution dcat:downloadURL ?downloadURL .
+      }
+      ORDER BY DESC(?modified)
+      LIMIT 1
+    "
+
+    response = Faraday.get(BASE_URL, {query: query})
+
+    if response.success?
+      dataset_url = response.body.split("\n")[1].strip
+      Upvs::FetchServicesWithFormsListJob.perform_now(dataset_url)
+    else
+      raise "Request to find latest dataset URL for set: #{SET_URL} failed with status code #{response.status}"
+    end
+  end
+end

--- a/app/jobs/upvs/find_services_with_forms_list_job.rb
+++ b/app/jobs/upvs/find_services_with_forms_list_job.rb
@@ -5,6 +5,7 @@ class Upvs::FindServicesWithFormsListJob < ApplicationJob
 
   SET_URL = 'https://data.gov.sk/set/9eeac271-ae1c-40f8-bb90-7089a9fcb659'
   BASE_URL = 'https://data.slovensko.sk/api/sparql'
+  NUMBER_OF_DATASET_FORMATS = 1
 
   def perform
     query = "
@@ -20,14 +21,16 @@ class Upvs::FindServicesWithFormsListJob < ApplicationJob
         ?distribution dcat:downloadURL ?downloadURL .
       }
       ORDER BY DESC(?modified)
-      LIMIT 1
+      LIMIT #{NUMBER_OF_DATASET_FORMATS}
     "
 
     response = Faraday.get(BASE_URL, {query: query})
 
     if response.success?
-      dataset_url = response.body.split("\n")[1].strip
-      Upvs::FetchServicesWithFormsListJob.perform_now(dataset_url)
+      dataset_url = response.body.split("\n")[1..].map(&:strip)
+                                                  .find { |url| Faraday.get(url).headers['Content-Disposition']&.include?('.zip') }
+
+      Upvs::FetchServicesWithFormsListJob.perform_now(dataset_url) if dataset_url
     else
       raise "Request to find latest dataset URL for set: #{SET_URL} failed with status code #{response.status}"
     end

--- a/lib/tasks/upvs.rake
+++ b/lib/tasks/upvs.rake
@@ -1,16 +1,16 @@
 namespace :upvs do
   desc 'Sync all public authority eDesks'
   task 'public_authority_edesks:sync' => :environment do
-    Upvs::FetchPublicAuthorityEdesksListJob.perform_later
+    Upvs::FindPublicAuthorityEdesksListJob.perform_later
   end
 
   desc 'Sync public authority eDesks'
   task 'public_authority_active_edesks:sync' => :environment do
-    Upvs::FetchPublicAuthorityActiveEdesksListJob.perform_later
+    Upvs::FindPublicAuthorityActiveEdesksListJob.perform_later
   end
 
   desc 'Sync services with forms list'
   task 'services_with_forms:sync' => :environment do
-    Upvs::FetchServicesWithFormsListJob.perform_later
+    Upvs::FindServicesWithFormsListJob.perform_later
   end
 end

--- a/spec/jobs/upvs/fetch_public_authority_active_edesks_list_job_spec.rb
+++ b/spec/jobs/upvs/fetch_public_authority_active_edesks_list_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Upvs::FetchPublicAuthorityActiveEdesksListJob, type: :job do
     it 'downloads and imports public authority eDesks in V1 format' do
       expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/active-edesks-v1.csv'))
 
-      subject.perform(downloader: downloader)
+      subject.perform(url ,downloader: downloader)
 
       expect(Upvs::PublicAuthorityActiveEdesk.first).to have_attributes(
         uri: 'ico://sk/00332674',
@@ -27,7 +27,7 @@ RSpec.describe Upvs::FetchPublicAuthorityActiveEdesksListJob, type: :job do
         expect(Upvs::PublicAuthorityActiveEdesk.count).to eq(10)
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/active-edesks-v1.csv'))
 
-        subject.perform(downloader: downloader)
+        subject.perform(url, downloader: downloader)
 
         expect(Upvs::PublicAuthorityActiveEdesk.count).to eq(7)
       end
@@ -37,7 +37,7 @@ RSpec.describe Upvs::FetchPublicAuthorityActiveEdesksListJob, type: :job do
       it 'does not import public authority eDesks' do
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/active-edesks-v1-not-matching.csv'))
 
-        expect { subject.perform(downloader: downloader) }.to raise_error(RuntimeError)
+        expect { subject.perform(url, downloader: downloader) }.to raise_error(RuntimeError)
 
         expect(Upvs::PublicAuthorityActiveEdesk.count).to eq(0)
       end
@@ -48,7 +48,7 @@ RSpec.describe Upvs::FetchPublicAuthorityActiveEdesksListJob, type: :job do
         expect(Upvs::PublicAuthorityActiveEdesk.count).to eq(10)
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/active-edesks-v1-not-matching.csv'))
 
-        expect { subject.perform(downloader: downloader) }.to raise_error(RuntimeError)
+        expect { subject.perform(url, downloader: downloader) }.to raise_error(RuntimeError)
 
         expect(Upvs::PublicAuthorityActiveEdesk.count).to eq(10)
       end
@@ -56,14 +56,14 @@ RSpec.describe Upvs::FetchPublicAuthorityActiveEdesksListJob, type: :job do
       it 'raises custom error' do
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/active-edesks-v1-not-matching.csv'))
 
-        expect { subject.perform(downloader: downloader) }.to raise_error('ico://sk/99166260 does not match 166260')
+        expect { subject.perform(url, downloader: downloader) }.to raise_error('ico://sk/99166260 does not match 166260')
       end
 
       it 'does not raise custom error if only leading zeros difference' do
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/active-edesks-v1-missing-leading-zeros.csv'))
 
         # subject.perform(downloader: downloader)
-        expect { subject.perform(downloader: downloader) }.not_to raise_error
+        expect { subject.perform(url, downloader: downloader) }.not_to raise_error
 
         expect(Upvs::PublicAuthorityActiveEdesk.last).to have_attributes(
           uri: 'ico://sk/214973_10001',
@@ -77,7 +77,7 @@ RSpec.describe Upvs::FetchPublicAuthorityActiveEdesksListJob, type: :job do
       it 'raises custom error' do
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/active-edesks-v1-incorrect-encoding.csv'))
 
-        expect { subject.perform(downloader: downloader) }.to raise_error('Incorrect encoding')
+        expect { subject.perform(url, downloader: downloader) }.to raise_error('Incorrect encoding')
       end
     end
   end

--- a/spec/jobs/upvs/fetch_public_authority_edesks_list_job_spec.rb
+++ b/spec/jobs/upvs/fetch_public_authority_edesks_list_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Upvs::FetchPublicAuthorityEdesksListJob, type: :job do
     it 'downloads and imports all public authority eDesks' do
       expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/edesks.csv'))
 
-      subject.perform(downloader: downloader)
+      subject.perform(url, downloader: downloader)
 
       expect(Upvs::PublicAuthorityEdesk.first).to have_attributes(
         uri: 'ico://sk/00332674',
@@ -27,7 +27,7 @@ RSpec.describe Upvs::FetchPublicAuthorityEdesksListJob, type: :job do
         expect(Upvs::PublicAuthorityEdesk.count).to eq(10)
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/edesks.csv'))
 
-        subject.perform(downloader: downloader)
+        subject.perform(url, downloader: downloader)
 
         expect(Upvs::PublicAuthorityEdesk.count).to eq(7)
       end
@@ -37,7 +37,7 @@ RSpec.describe Upvs::FetchPublicAuthorityEdesksListJob, type: :job do
       it 'does not import public authority eDesks' do
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/edesks-not-matching.csv'))
 
-        expect { subject.perform(downloader: downloader) }.to raise_error(RuntimeError)
+        expect { subject.perform(url, downloader: downloader) }.to raise_error(RuntimeError)
 
         expect(Upvs::PublicAuthorityEdesk.count).to eq(0)
       end
@@ -48,7 +48,7 @@ RSpec.describe Upvs::FetchPublicAuthorityEdesksListJob, type: :job do
         expect(Upvs::PublicAuthorityEdesk.count).to eq(10)
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/edesks-not-matching.csv'))
 
-        expect { subject.perform(downloader: downloader) }.to raise_error(RuntimeError)
+        expect { subject.perform(url, downloader: downloader) }.to raise_error(RuntimeError)
 
         expect(Upvs::PublicAuthorityEdesk.count).to eq(10)
       end
@@ -56,13 +56,13 @@ RSpec.describe Upvs::FetchPublicAuthorityEdesksListJob, type: :job do
       it 'raises custom error' do
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/edesks-not-matching.csv'))
 
-        expect { subject.perform(downloader: downloader) }.to raise_error('ico://sk/99166260 does not match 166260')
+        expect { subject.perform(url, downloader: downloader) }.to raise_error('ico://sk/99166260 does not match 166260')
       end
 
       it 'does not raise custom error if only leading zeros difference' do
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/edesks-missing-leading-zeros.csv'))
 
-        expect { subject.perform(downloader: downloader) }.not_to raise_error
+        expect { subject.perform(url, downloader: downloader) }.not_to raise_error
 
         expect(Upvs::PublicAuthorityEdesk.last).to have_attributes(
           uri: 'ico://sk/214973_10001',
@@ -76,7 +76,7 @@ RSpec.describe Upvs::FetchPublicAuthorityEdesksListJob, type: :job do
       it 'raises custom error' do
         expect(downloader).to receive(:download_file).with(url).and_return(fixture_filepath('upvs/edesks-incorrect-encoding.csv'))
 
-        expect { subject.perform(downloader: downloader) }.to raise_error('Incorrect encoding')
+        expect { subject.perform(url, downloader: downloader) }.to raise_error('Incorrect encoding')
       end
     end
   end

--- a/spec/jobs/upvs/fetch_services_with_forms_list_job_spec.rb
+++ b/spec/jobs/upvs/fetch_services_with_forms_list_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Upvs::FetchServicesWithFormsListJob, type: :job do
         HarvesterUtils::Downloader.extract_csv(zip_file)
       end
 
-      subject.perform(downloader: downloader)
+      subject.perform(url, downloader: downloader)
 
       expect(Upvs::ServiceWithForm.first).to have_attributes(
         instance_id: 2083,
@@ -36,7 +36,7 @@ RSpec.describe Upvs::FetchServicesWithFormsListJob, type: :job do
         HarvesterUtils::Downloader.extract_csv(zip_file)
       end
 
-      subject.perform(downloader: downloader)
+      subject.perform(url, downloader: downloader)
 
       expect(Upvs::ServiceWithForm.first).to have_attributes(
         instance_id: 2082,
@@ -60,7 +60,7 @@ RSpec.describe Upvs::FetchServicesWithFormsListJob, type: :job do
         HarvesterUtils::Downloader.extract_csv(zip_file)
       end
 
-      subject.perform(downloader: downloader)
+      subject.perform(url, downloader: downloader)
 
       expect(Upvs::ServiceWithForm.first).to have_attributes(
         instance_id: 2088,
@@ -85,7 +85,7 @@ RSpec.describe Upvs::FetchServicesWithFormsListJob, type: :job do
           HarvesterUtils::Downloader.extract_csv(zip_file)
         end
 
-        subject.perform(downloader: downloader)
+        subject.perform(url, downloader: downloader)
 
         expect(Upvs::ServiceWithForm.first).to have_attributes(
           instance_id: 29644,
@@ -114,7 +114,7 @@ RSpec.describe Upvs::FetchServicesWithFormsListJob, type: :job do
           HarvesterUtils::Downloader.extract_csv(zip_file)
         end
 
-        subject.perform(downloader: downloader)
+        subject.perform(url, downloader: downloader)
 
         expect(Upvs::ServiceWithForm.count).to eq(20)
       end

--- a/spec/jobs/upvs/find_public_authority_active_edesks_list_job_spec.rb
+++ b/spec/jobs/upvs/find_public_authority_active_edesks_list_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Upvs::FindPublicAuthorityActiveEdesksListJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:csv_url) { 'https://data.slovensko.sk/download?id=794af827-132b-46d1-98e7-ccd73eda26e0' }
+  let(:xlsx_url) { 'https://data.slovensko.sk/download?id=2350ef8f-9b8f-43c0-b075-dda38dd052d1' }
+
+  after do
+    clear_enqueued_jobs
+  end
+
+  describe "#perform" do
+    before do
+      stub_request(:get, "https://data.slovensko.sk/api/sparql")
+        .with(query: hash_including({"query": kind_of(String)}))
+        .to_return(status: 200, body: "downloadURL\n#{csv_url}\n#{xlsx_url}\n")
+
+      stub_request(:get, csv_url).to_return(headers: {'Content-Disposition': 'filename.csv'})
+      stub_request(:get, xlsx_url).to_return(headers: {'Content-Disposition': 'filename.xlsx'})
+    end
+
+    it 'calls FetchPublicAuthorityActiveEdesksListJob with correct dataset url' do
+      expect(Upvs::FetchPublicAuthorityActiveEdesksListJob).to receive(:perform_now).with(csv_url)
+      subject.perform
+    end
+
+    it 'raises an error when the request is unsuccessful' do
+      stub_request(:get, "https://data.slovensko.sk/api/sparql")
+        .with(query: hash_including({"query": kind_of(String)}))
+        .to_return(status: 500, body: "Internal Server Error\n")
+
+      expect {
+        subject.perform
+      }.to raise_error(/Request to find latest dataset URL for set:/)
+    end
+  end
+end

--- a/spec/jobs/upvs/find_public_authority_edesks_list_job_spec.rb
+++ b/spec/jobs/upvs/find_public_authority_edesks_list_job_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Upvs::FindPublicAuthorityEdesksListJob, type: :job do
       stub_request(:get, "https://data.slovensko.sk/api/sparql")
         .with(query: hash_including({"query": kind_of(String)}))
         .to_return(status: 200, body: "downloadURL\n#{url}\n")
+
+      stub_request(:get, url).to_return(headers: {'Content-Disposition': 'filename.csv'})
     end
 
     it 'calls FetchPublicAuthorityEdesksListJob with correct dataset url' do

--- a/spec/jobs/upvs/find_public_authority_edesks_list_job_spec.rb
+++ b/spec/jobs/upvs/find_public_authority_edesks_list_job_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Upvs::FindPublicAuthorityEdesksListJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:url) { 'https://data.slovensko.sk/download?id=7c70f6c9-1777-4d8a-8711-f1dfd2359620' }
+
+  after do
+    clear_enqueued_jobs
+  end
+
+  describe "#perform" do
+    before do
+      stub_request(:get, "https://data.slovensko.sk/api/sparql")
+        .with(query: hash_including({"query": kind_of(String)}))
+        .to_return(status: 200, body: "downloadURL\n#{url}\n")
+    end
+
+    it 'calls FetchPublicAuthorityEdesksListJob with correct dataset url' do
+      expect(Upvs::FetchPublicAuthorityEdesksListJob).to receive(:perform_now).with(url)
+      subject.perform
+    end
+
+    it 'raises an error when the request is unsuccessful' do
+      stub_request(:get, "https://data.slovensko.sk/api/sparql")
+        .with(query: hash_including({"query": kind_of(String)}))
+        .to_return(status: 500, body: "Internal Server Error\n")
+
+      expect {
+        subject.perform
+      }.to raise_error(/Request to find latest dataset URL for set:/)
+    end
+  end
+end

--- a/spec/jobs/upvs/find_services_with_forms_list_job_spec.rb
+++ b/spec/jobs/upvs/find_services_with_forms_list_job_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Upvs::FindServicesWithFormsListJob, type: :job do
       stub_request(:get, "https://data.slovensko.sk/api/sparql")
         .with(query: hash_including({"query": kind_of(String)}))
         .to_return(status: 200, body: "downloadURL\n#{url}\n")
+
+      stub_request(:get, url).to_return(headers: {'Content-Disposition': 'filename.zip'})
     end
 
     it 'calls FetchServicesWithFormsListJob with correct dataset url' do

--- a/spec/jobs/upvs/find_services_with_forms_list_job_spec.rb
+++ b/spec/jobs/upvs/find_services_with_forms_list_job_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Upvs::FindServicesWithFormsListJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:url) { 'https://data.slovensko.sk/download?id=c78de203-caa5-4d1d-9496-975f0e2567d1' }
+
+  after do
+    clear_enqueued_jobs
+  end
+
+  describe "#perform" do
+    before do
+      stub_request(:get, "https://data.slovensko.sk/api/sparql")
+        .with(query: hash_including({"query": kind_of(String)}))
+        .to_return(status: 200, body: "downloadURL\n#{url}\n")
+    end
+
+    it 'calls FetchServicesWithFormsListJob with correct dataset url' do
+      expect(Upvs::FetchServicesWithFormsListJob).to receive(:perform_now).with(url)
+      subject.perform
+    end
+
+    it 'raises an error when the request is unsuccessful' do
+      stub_request(:get, "https://data.slovensko.sk/api/sparql")
+        .with(query: hash_including({"query": kind_of(String)}))
+        .to_return(status: 500, body: "Internal Server Error\n")
+
+      expect {
+        subject.perform
+      }.to raise_error(/Request to find latest dataset URL for set:/)
+    end
+  end
+end


### PR DESCRIPTION
- Vytvoril som nové joby, ktoré hľadajú aktuálne URL pre sťahovanie UPVS datasetov
- Tieto joby pošlú najdenú URL už do existujúcich fetch jobov
- Zmenil som UPVS rake tasks aby volal tieto nové joby, ktoré potom volajú fetch
- Upravil som pôvodne fetch joby a ich testy
- Pridal som testy pre nové joby
- V jobe [FindPublicAuthorityActiveEdesksListJob](https://github.com/slovensko-digital/harvester.ecosystem/blob/1504c675369f0a1f4fc1f8f5e1f94a9d7e566f5b/app/jobs/upvs/find_public_authority_active_edesks_list_job.rb), sú tam vždy publikované dve verzie, ktoré majú rovnaký čas vytvorenia aj modifkácie, jeden je však formát `.xlsx` a druhý `.csv`, preto je tam táto kontrola

Ešte tu možno priložím web, kde som našiel návod [dokumentácia](https://wiki.vicepremier.gov.sk/pages/viewpage.action?pageId=155320437)