### PR TITLE
SD-2744/Metais-sync-project-fail-on-null-investment-type

### DIFF
--- a/db/migrate/20240709105101_allow_null_for_typ_investicie_in_metais_project_versions.rb
+++ b/db/migrate/20240709105101_allow_null_for_typ_investicie_in_metais_project_versions.rb
@@ -1,0 +1,5 @@
+class AllowNullForTypInvesticieInMetaisProjectVersions < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null 'metais.project_versions', :typ_investicie, null: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4510,7 +4510,7 @@ CREATE TABLE metais.project_versions (
     project_id bigint NOT NULL,
     nazov character varying NOT NULL,
     kod_metais character varying NOT NULL,
-    typ_investicie character varying NOT NULL,
+    typ_investicie character varying,
     prijimatel character varying,
     faza_projektu character varying,
     program character varying,
@@ -11065,6 +11065,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220919084308'),
 ('20221219105855'),
 ('20231106173059'),
-('20231107130000');
+('20231107130000'),
+('20240709105101');
 
 


### PR DESCRIPTION
Allowed null for column typ_investicie for table metais.project_versions, because there are projects without this attribute