### PR TITLE
SD-2693/Metais-rake-tasks-execution-time-changed

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -15,6 +15,6 @@ module Clockwork
   every(1.day, 'itms:sync', at: '5:00')
   every(1.day, 'itms:detect_api_changes', at: '9:00')
 
-  every(1.day, 'metais:sync_codelists', at: '5:30')
-  every(1.day, 'metais:sync', at: '6:00')
+  every(1.day, 'metais:sync_codelists', at: '2:30')
+  every(1.day, 'metais:sync', at: '3:00')
 end


### PR DESCRIPTION
Moved the execution of metais tasks, so we can run redflags sync sooner.