### PR TITLE
Add self.inheritance_column = nil to TemporaryServiceWithForm

### DIFF
--- a/app/jobs/upvs/fetch_services_with_forms_list_job.rb
+++ b/app/jobs/upvs/fetch_services_with_forms_list_job.rb
@@ -27,6 +27,8 @@ class Upvs::FetchServicesWithFormsListJob < ApplicationJob
   end
 
   class TemporaryServiceWithForm < TemporaryRecord
+    self.inheritance_column = nil
+
     def self.source
       Upvs::ServiceWithForm
     end


### PR DESCRIPTION
Failuje tento job s: `The single-table inheritance mechanism failed to locate the subclass: 'Formulárové služby'. This error is raised because the column 'type' is reserved for storing the class in case of inheritance.`